### PR TITLE
16-color variants

### DIFF
--- a/tmuxcolors-256.conf
+++ b/tmuxcolors-256.conf
@@ -1,4 +1,4 @@
-#### COLOUR
+#### COLOUR (Solarized 256)
 
 # default statusbar colors
 set-option -g status-bg colour235 #base02
@@ -6,7 +6,7 @@ set-option -g status-fg colour136 #yellow
 set-option -g status-attr default
 
 # default window title colors
-set-window-option -g window-status-fg colour244
+set-window-option -g window-status-fg colour244 #base0
 set-window-option -g window-status-bg default
 #set-window-option -g window-status-attr dim
 

--- a/tmuxcolors-dark.conf
+++ b/tmuxcolors-dark.conf
@@ -1,0 +1,31 @@
+#### COLOUR (Solarized dark)
+
+# default statusbar colors
+set-option -g status-bg black #base02
+set-option -g status-fg yellow #yellow
+set-option -g status-attr default
+
+# default window title colors
+set-window-option -g window-status-fg brightblue #base0
+set-window-option -g window-status-bg default
+#set-window-option -g window-status-attr dim
+
+# active window title colors
+set-window-option -g window-status-current-fg brightred #orange
+set-window-option -g window-status-current-bg default
+#set-window-option -g window-status-current-attr bright
+
+# pane border
+set-option -g pane-border-fg black #base02
+set-option -g pane-active-border-fg brightgreen #base01
+
+# message text
+set-option -g message-bg black #base02
+set-option -g message-fg brightred #orange
+
+# pane number display
+set-option -g display-panes-active-colour blue #blue
+set-option -g display-panes-colour brightred #orange
+
+# clock
+set-window-option -g clock-mode-colour green #green

--- a/tmuxcolors-light.conf
+++ b/tmuxcolors-light.conf
@@ -1,0 +1,31 @@
+#### COLOUR (Solarized light)
+
+# default statusbar colors
+set-option -g status-bg white #base2
+set-option -g status-fg yellow #yellow
+set-option -g status-attr default
+
+# default window title colors
+set-window-option -g window-status-fg brightyellow #base00
+set-window-option -g window-status-bg default
+#set-window-option -g window-status-attr dim
+
+# active window title colors
+set-window-option -g window-status-current-fg brightred #orange
+set-window-option -g window-status-current-bg default
+#set-window-option -g window-status-current-attr bright
+
+# pane border
+set-option -g pane-border-fg white #base2
+set-option -g pane-active-border-fg brightcyan #base1
+
+# message text
+set-option -g message-bg white #base2
+set-option -g message-fg brightred #orange
+
+# pane number display
+set-option -g display-panes-active-colour blue #blue
+set-option -g display-panes-colour brightred #orange
+
+# clock
+set-window-option -g clock-mode-colour green #green


### PR DESCRIPTION
The dark version converts your 256-color values directly into their corresponding 16-color values. The light version inverts the base colors. These work well in gnome-terminal configured with https://github.com/sigurdga/gnome-terminal-colors-solarized. Let me know if you'd rather do this in a different way.
