### PR TITLE
Enable theme configuration via tmux option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Add plugin to the list of TPM plugins in `.tmux.conf`:
 
 Hit `prefix + I` to fetch the plugin and source it. The plugin should now be working.
 
+3 themes are provided so you can pick and choose via `.tmux.conf` option:
+
+- `set -g @colors-solarized '256'` (the default)
+- `set -g @colors-solarized 'dark'`
+- `set -g @colors-solarized 'light'`
+
 ## Screenshot
 Here is a screenshot of a tmux session captured from a gnome-terminal using the [dz-version of the awesome Inconsolata font](http://nodnod.net/2009/feb/12/adding-straight-single-and-double-quotes-inconsola/).
 

--- a/tmuxcolors.tmux
+++ b/tmuxcolors.tmux
@@ -2,7 +2,22 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+theme_option="@colors-solarized"
+default_theme="256"
+
+get_tmux_option() {
+	local option="$1"
+	local default_value="$2"
+	local option_value="$(tmux show-option -gqv "$option")"
+	if [ -z "$option_value" ]; then
+		echo "$default_value"
+	else
+		echo "$option_value"
+	fi
+}
+
 main() {
-	tmux source-file "$CURRENT_DIR/tmuxcolors-256.conf"
+	local theme="$(get_tmux_option "$theme_option" "$default_theme")"
+	tmux source-file "$CURRENT_DIR/tmuxcolors-${theme}.conf"
 }
 main


### PR DESCRIPTION
Naturally this option will only work if the plugin was loaded with tmux
plugin manager. @breerly asked for this feature in [this comment](https://github.com/seebi/tmux-colors-solarized/issues/9#issuecomment-132391997).

This setting is optional. If not present, the default `256` theme will be loaded.

Please let me know if you have any objections to this (e.g. wording) and I'll amended!