### PR TITLE
Update *.conf files to use applicable `-style` properties

### DIFF
--- a/tmuxcolors-256.conf
+++ b/tmuxcolors-256.conf
@@ -3,25 +3,24 @@
 # default statusbar colors
 set-option -g status-bg colour235 #base02
 set-option -g status-fg colour136 #yellow
-set-option -g status-attr default
 
 # default window title colors
-set-window-option -g window-status-fg colour244 #base0
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=colour244 #base0
+set-window-option -g window-status-style bg=default
+#set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-fg colour166 #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=colour166 #orange
+set-window-option -g window-status-current-style bg=default
+#set-window-option -g window-status-current-style bright
 
 # pane border
-set-option -g pane-border-fg colour235 #base02
-set-option -g pane-active-border-fg colour240 #base01
+set-option -g pane-border-style fg=colour235 #base02
+set-option -g pane-active-border-style fg=colour240 #base01
 
 # message text
-set-option -g message-bg colour235 #base02
-set-option -g message-fg colour166 #orange
+set-option -g message-style bg=colour235 #base02
+set-option -g message-style fg=colour166 #orange
 
 # pane number display
 set-option -g display-panes-active-colour colour33 #blue

--- a/tmuxcolors-256.conf
+++ b/tmuxcolors-256.conf
@@ -1,17 +1,14 @@
 #### COLOUR (Solarized 256)
 
 # default statusbar colors
-set-option -g status-style bg=colour235 #base02
-set-option -g status-style fg=colour136 #yellow
+set-option -g status-style fg=colour136,bg=colour235 #yellow and base02
 
 # default window title colors
-set-window-option -g window-status-style fg=colour244 #base0
-set-window-option -g window-status-style bg=default
+set-window-option -g window-status-style fg=colour244,bg=default #base0 and default
 #set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-style fg=colour166 #orange
-set-window-option -g window-status-current-style bg=default
+set-window-option -g window-status-current-style fg=colour166,bg=default #orange and default
 #set-window-option -g window-status-current-style bright
 
 # pane border
@@ -19,8 +16,7 @@ set-option -g pane-border-style fg=colour235 #base02
 set-option -g pane-active-border-style fg=colour240 #base01
 
 # message text
-set-option -g message-style bg=colour235 #base02
-set-option -g message-style fg=colour166 #orange
+set-option -g message-style fg=colour166,bg=colour235 #orange and base02
 
 # pane number display
 set-option -g display-panes-active-colour colour33 #blue

--- a/tmuxcolors-256.conf
+++ b/tmuxcolors-256.conf
@@ -1,8 +1,8 @@
 #### COLOUR (Solarized 256)
 
 # default statusbar colors
-set-option -g status-bg colour235 #base02
-set-option -g status-fg colour136 #yellow
+set-option -g status-style bg=colour235 #base02
+set-option -g status-style fg=colour136 #yellow
 
 # default window title colors
 set-window-option -g window-status-style fg=colour244 #base0

--- a/tmuxcolors-base16.conf
+++ b/tmuxcolors-base16.conf
@@ -16,25 +16,24 @@
 # default statusbar colors
 set-option -g status-bg colour18 #base2
 set-option -g status-fg yellow #yellow
-set-option -g status-attr default
 
 # default window title colors
-set-window-option -g window-status-fg colour20 #base00
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=colour20 #base00
+set-window-option -g window-status-style bg=default
+#set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-fg colour16 #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=colour16 #orange
+set-window-option -g window-status-current-style bg=default
+#set-window-option -g window-status-current-style bright
 
 # pane border
-set-option -g pane-border-fg colour18 #base2
-set-option -g pane-active-border-fg colour19 #base1
+set-option -g pane-border-style fg=colour18 #base2
+set-option -g pane-active-border-style fg=colour19 #base1
 
 # message text
-set-option -g message-bg colour18 #base2
-set-option -g message-fg colour16 #orange
+set-option -g message-style bg=colour18 #base2
+set-option -g message-style fg=colour16 #orange
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-base16.conf
+++ b/tmuxcolors-base16.conf
@@ -14,8 +14,8 @@
 # base16-solarized-dark terminal/shell color themes.
 
 # default statusbar colors
-set-option -g status-bg colour18 #base2
-set-option -g status-fg yellow #yellow
+set-option -g status-style bg=colour18 #base2
+set-option -g status-style fg=yellow #yellow
 
 # default window title colors
 set-window-option -g window-status-style fg=colour20 #base00

--- a/tmuxcolors-base16.conf
+++ b/tmuxcolors-base16.conf
@@ -14,17 +14,14 @@
 # base16-solarized-dark terminal/shell color themes.
 
 # default statusbar colors
-set-option -g status-style bg=colour18 #base2
-set-option -g status-style fg=yellow #yellow
+set-option -g status-style fg=yellow,bg=colour18 #yellow and base2
 
 # default window title colors
-set-window-option -g window-status-style fg=colour20 #base00
-set-window-option -g window-status-style bg=default
+set-window-option -g window-status-style fg=colour20,bg=default #base00 and default
 #set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-style fg=colour16 #orange
-set-window-option -g window-status-current-style bg=default
+set-window-option -g window-status-current-style fg=colour16,bg=default #orange and default
 #set-window-option -g window-status-current-style bright
 
 # pane border
@@ -32,8 +29,7 @@ set-option -g pane-border-style fg=colour18 #base2
 set-option -g pane-active-border-style fg=colour19 #base1
 
 # message text
-set-option -g message-style bg=colour18 #base2
-set-option -g message-style fg=colour16 #orange
+set-option -g message-style fg=colour16,bg=colour18 #orange and base2
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-dark.conf
+++ b/tmuxcolors-dark.conf
@@ -3,25 +3,24 @@
 # default statusbar colors
 set-option -g status-bg black #base02
 set-option -g status-fg yellow #yellow
-set-option -g status-attr default
 
 # default window title colors
-set-window-option -g window-status-fg brightblue #base0
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=brightblue #base0
+set-window-option -g window-status-style bg=default
+#set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-fg brightred #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=brightred #orange
+set-window-option -g window-status-current-style bg=default
+#set-window-option -g window-status-current-style bright
 
 # pane border
-set-option -g pane-border-fg black #base02
-set-option -g pane-active-border-fg brightgreen #base01
+set-option -g pane-border-style fg=black #base02
+set-option -g pane-active-border-style fg=brightgreen #base01
 
 # message text
-set-option -g message-bg black #base02
-set-option -g message-fg brightred #orange
+set-option -g message-style bg=black #base01
+set-option -g message-style fg=brightred #orange
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-dark.conf
+++ b/tmuxcolors-dark.conf
@@ -1,17 +1,14 @@
 #### COLOUR (Solarized dark)
 
 # default statusbar colors
-set-option -g status-style bg=black #base02
-set-option -g status-style fg=yellow #yellow
+set-option -g status-style fg=yellow,bg=black #yellow and base02
 
 # default window title colors
-set-window-option -g window-status-style fg=brightblue #base0
-set-window-option -g window-status-style bg=default
+set-window-option -g window-status-style fg=brightblue,bg=default #base0 and default
 #set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-style fg=brightred #orange
-set-window-option -g window-status-current-style bg=default
+set-window-option -g window-status-current-style fg=brightred,bg=default #orange and default
 #set-window-option -g window-status-current-style bright
 
 # pane border
@@ -19,8 +16,7 @@ set-option -g pane-border-style fg=black #base02
 set-option -g pane-active-border-style fg=brightgreen #base01
 
 # message text
-set-option -g message-style bg=black #base01
-set-option -g message-style fg=brightred #orange
+set-option -g message-style fg=brightred,bg=black #orange and base01
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-dark.conf
+++ b/tmuxcolors-dark.conf
@@ -1,8 +1,8 @@
 #### COLOUR (Solarized dark)
 
 # default statusbar colors
-set-option -g status-bg black #base02
-set-option -g status-fg yellow #yellow
+set-option -g status-style bg=black #base02
+set-option -g status-style fg=yellow #yellow
 
 # default window title colors
 set-window-option -g window-status-style fg=brightblue #base0

--- a/tmuxcolors-light.conf
+++ b/tmuxcolors-light.conf
@@ -3,25 +3,24 @@
 # default statusbar colors
 set-option -g status-bg white #base2
 set-option -g status-fg yellow #yellow
-set-option -g status-attr default
 
 # default window title colors
-set-window-option -g window-status-fg brightyellow #base00
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=brightyellow #base00
+set-window-option -g window-status-style bg=default
+#set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-fg brightred #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=brightred #orange
+set-window-option -g window-status-current-style bg=default
+#set-window-option -g window-status-current-style bright
 
 # pane border
-set-option -g pane-border-fg white #base2
-set-option -g pane-active-border-fg brightcyan #base1
+set-option -g pane-border-style fg=white #base2
+set-option -g pane-active-border-style fg=brightcyan #base1
 
 # message text
-set-option -g message-bg white #base2
-set-option -g message-fg brightred #orange
+set-option -g message-style bg=white #base2
+set-option -g message-style fg=brightred #orange
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-light.conf
+++ b/tmuxcolors-light.conf
@@ -1,17 +1,14 @@
 #### COLOUR (Solarized light)
 
 # default statusbar colors
-set-option -g status-style bg=white #base2
-set-option -g status-style fg=yellow #yellow
+set-option -g status-style fg=yellow,bg=white #yellow and base2
 
 # default window title colors
-set-window-option -g window-status-style fg=brightyellow #base00
-set-window-option -g window-status-style bg=default
+set-window-option -g window-status-style fg=brightyellow,bg=default #base0 and default
 #set-window-option -g window-status-style dim
 
 # active window title colors
-set-window-option -g window-status-current-style fg=brightred #orange
-set-window-option -g window-status-current-style bg=default
+set-window-option -g window-status-current-style fg=brightred,bg=default #orange and default
 #set-window-option -g window-status-current-style bright
 
 # pane border
@@ -19,8 +16,7 @@ set-option -g pane-border-style fg=white #base2
 set-option -g pane-active-border-style fg=brightcyan #base1
 
 # message text
-set-option -g message-style bg=white #base2
-set-option -g message-style fg=brightred #orange
+set-option -g message-style fg=brightred,bg=white #orange and base2
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmuxcolors-light.conf
+++ b/tmuxcolors-light.conf
@@ -1,8 +1,8 @@
 #### COLOUR (Solarized light)
 
 # default statusbar colors
-set-option -g status-bg white #base2
-set-option -g status-fg yellow #yellow
+set-option -g status-style bg=white #base2
+set-option -g status-style fg=yellow #yellow
 
 # default window title colors
 set-window-option -g window-status-style fg=brightyellow #base00


### PR DESCRIPTION
See https://github.com/seebi/tmux-colors-solarized/issues/22

`status-attr`, `window-status-fg`, `window-status-bg`, `window-status-current-fg`, `window-status-current-bg`, `pane-border-fg`, `pane-active-border-fg`, `message-bg` and `message-fg` have been removed from tmux.

See https://github.com/tmux/tmux/commit/f34ebfed7698ce41fe7bae756c0bb0c485e8bfdb