### PR TITLE
align active/current color for windows & panes

### DIFF
--- a/tmuxcolors-dark.conf
+++ b/tmuxcolors-dark.conf
@@ -19,8 +19,8 @@ set-option -g pane-active-border-style fg=brightgreen #base01
 set-option -g message-style fg=brightred,bg=black #orange and base01
 
 # pane number display
-set-option -g display-panes-active-colour blue #blue
-set-option -g display-panes-colour brightred #orange
+set-option -g display-panes-active-colour brightred #orange
+set-option -g display-panes-colour blue #blue
 
 # clock
 set-window-option -g clock-mode-colour green #green


### PR DESCRIPTION
With this applied the color `brightred` is used for both the active window (bottom left corner) and the active pane index (`0` in the center).
![tmux-aligned-colors](https://user-images.githubusercontent.com/1704798/63488698-c86ef780-c464-11e9-8dac-6b7df5d40e47.png)
